### PR TITLE
fix: node positioning in Safari #21

### DIFF
--- a/src/components/Group.vue
+++ b/src/components/Group.vue
@@ -16,6 +16,7 @@
 <script>
 /** */
 import drag from '../mixins/drag.js'
+import util from "../util";
 export default {
   mixins: [
     drag
@@ -47,7 +48,8 @@ export default {
       margin: vm.margin + 'px',
       width: `calc(100% - ${vm.margin * 2}px)`,
       height: `calc(100% - ${vm.margin * 2}px)`
-    })
+    }),
+    position: () => util.isSafari() ? 'static': 'absolute'
   },
   methods: {
     onDrag ({ x,y }) {
@@ -71,7 +73,7 @@ export default {
 .group .content {
   width: 100%;
   height: 100%;
-  position: absolute;
+  position: v-bind('position');
   border-radius: 7px;
   background-color: rgba(100, 100, 100, .25);
   display: inline-block;

--- a/src/components/Node.vue
+++ b/src/components/Node.vue
@@ -23,6 +23,7 @@
 
 <script>
 import dragMixin from '../mixins/drag.js'
+import util from '../util.js'
 export default {
   mixins: [
     dragMixin
@@ -51,6 +52,11 @@ export default {
       type: Boolean,
       default: false
     },
+  },
+  computed: {
+    position () {
+      return util.isSafari() ? 'static': 'relative'
+    }
   },
   mounted () {
     if (this.fit) {
@@ -82,7 +88,7 @@ export default {
 
 <style>
 .node .content {
-  position: relative;
+  position: v-bind("position");
   white-space: nowrap;
   width: fit-content;
 }

--- a/src/components/Port.vue
+++ b/src/components/Port.vue
@@ -5,6 +5,8 @@
 </template>
 
 <script>
+import util from "../util";
+
 /**
  * Offsets edges to its position when placed inside a node
  */
@@ -23,7 +25,8 @@ export default {
   },
   data() {
     return {
-      offset: { x: 0, y: 0 }
+      offset: { x: 0, y: 0 },
+      position: util.isSafari() ? 'static': 'relative'
     }
   },
   mounted () {
@@ -65,6 +68,6 @@ export default {
 
 <style>
 .port {
-  position: relative;
+  position: v-bind("position");
 }
 </style>

--- a/src/util.js
+++ b/src/util.js
@@ -199,6 +199,18 @@ function lineLine(x1, y1, x2, y2, x3, y3, x4, y4) {
   }
   return { x, y }
 }
+function isSafari() {
+  return window
+    ? /constructor/i.test(window.HTMLElement) ||
+    (function (p) {
+      return p?.toString() === "[object SafariRemoteNotification]";
+    })(
+      !window["safari"] ||
+      (typeof safari !== "undefined" && window["safari"].pushNotification),
+    ) || /iPad|iPhone|iPod/.test(navigator.userAgent) && !window["MSStream"]
+
+    : false;
+}
 
 export default {
   findPosition,
@@ -207,5 +219,6 @@ export default {
   boxBox,
   boxBoxes,
   lineLine,
-  lineRect
+  lineRect,
+  isSafari
 }


### PR DESCRIPTION
This commit addresses an inconsistency in SVG element positioning observed on Safari. To ensure consistent rendering across browsers, static positioning is now used only for Safari.

Safari can sometimes have issues with `position: relative` within SVGs, especially when used with clipping paths or other complex elements.